### PR TITLE
Use encrypted storage for OTP secret

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
    <application
         android:label="XL Authenticator"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+</full-backup-content>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,6 +90,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
 
   url_launcher: ^6.0.3
 
+  flutter_secure_storage: ^4.2.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This first checks to see if a secret has been stored in [Flutter Secure Storage](https://pub.dev/packages/flutter_secure_storage/versions/4.2.0). If a secret is found there, it uses that. If not, it checks to see if a secret is stored in Shared Preferences. If one is found it immediately saves the secret to Flutter Secure Storage and then deletes it from Shared Preferences.

This works on my Android device, but I don't have an iOS device to test this on.