### PR TITLE
Fix and improve the sendOtp for loop

### DIFF
--- a/lib/communication.dart
+++ b/lib/communication.dart
@@ -29,7 +29,7 @@ class Communication {
 
     List<String>? ipList = ips.split(';');
 
-    for (var currentIp = 0; currentIp < ips.length; currentIp++) {
+    for (var currentIp = 0; currentIp < ipList.length; currentIp++) {
       var ip = ipList[currentIp];
       var uri = Uri.http("$ip:4646", "ffxivlauncher/$otp");
       try {

--- a/lib/communication.dart
+++ b/lib/communication.dart
@@ -27,24 +27,25 @@ class Communication {
     if (ips == null)
       return false;
 
-    List<String>? ipList = ips.split(';');
+    List<String> ipList = ips.split(";");
+    return await Future.any(ipList.map((e) => sendOtpToIp(otp, e)));
+  }
 
-    for (var currentIp = 0; currentIp < ipList.length; currentIp++) {
-      var ip = ipList[currentIp];
-      var uri = Uri.http("$ip:4646", "ffxivlauncher/$otp");
-      try {
-        await http.get(uri);
-      } on http
-          .ClientException catch (e) { // This happens since the XL http server is badly implemented, no problem though
-        developer.log('ClientException: ' + uri.toString(),
-            name: 'com.goatsoft.xl_otpsend', error: e);
-        return true;
-      }
-      catch (e) {
-        developer.log('could not send to: ' + uri.toString(),
-            name: 'com.goatsoft.xl_otpsend', error: e);
-      }
+  static Future<bool> sendOtpToIp(String otp, String ip) async {
+    var uri = Uri.http("$ip:4646", "ffxivlauncher/$otp");
+    try {
+      await http.get(uri).timeout(const Duration(seconds: 5));
+      return true;
+    } on http
+        .ClientException catch (e) { // This happens since the XL http server is badly implemented, no problem though
+      developer.log('ClientException: ' + uri.toString(),
+          name: 'com.goatsoft.xl_otpsend', error: e);
+      return true;
     }
-    return true;
+    catch (e) {
+      developer.log('could not send to: ' + uri.toString(),
+          name: 'com.goatsoft.xl_otpsend', error: e);
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Currently, the sendOtp loop is using the `ips` string's length to loop, which is wrong.

I took the opportunity and changed up the code so it's cleaner (I think?) and doesn't hang if one of the hosts isn't reachable (which will be 99% of the time if the user configured more than one IP address): now, the app will shoot the OTP code to all configured clients and use the first reply received as the condition to autoclose or not.

Since any client that's actually waiting for the code will be quick to reply (while the other clients won't be running at all), this will make it feel like the current (mono-IP) version in which the app quickly opens and closes. If the user opened the app without any client running, it'll timeout all requests in five seconds and not autoclose.